### PR TITLE
Update charmcraft version for charm-vault stable/1.8

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -188,7 +188,7 @@ projects:
           - "22.10"
       stable/1.8:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "2.1/stable"
         channels:
           - 1.8/stable
         bases:


### PR DESCRIPTION
The backport of "Implement cert cache for vault units (v3)"[0] bumps up the dependency of charmcraft from 2.0 to 2.1

[0] https://review.opendev.org/c/openstack/charm-vault/+/871248