### PR TITLE
percona-cluster: track stable/bionic git branch

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -109,7 +109,7 @@ projects:
           - latest/edge
         bases:
           - "18.04"
-      stable/5.7:
+      stable/bionic:
         build-channels:
           charmcraft: "1.5/stable"
         channels:


### PR DESCRIPTION
The stable/5.7 git branch is incorrect, misc charms have their stable branches named after the LTS they track.