### PR TITLE
Fix ironic recipe to be 2.1/stable for charmcraft

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1024,7 +1024,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "2.1/stable"
         channels:
           - latest/edge
         bases:


### PR DESCRIPTION
The master branch was updated but the recipe was not (on LP) nor in this repo.