### PR TITLE
rabbitmq-server: rename branch to stable/bionic

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -152,7 +152,7 @@ projects:
           - "18.04"
           - "20.04"
       # bionic - not enabled yet
-      stable/3.6:
+      stable/bionic:
         build-channels:
           charmcraft: "1.5/stable"
         channels:


### PR DESCRIPTION
Stable branches for misc charms get their name from the Ubuntu series they get their payload from.