### PR TITLE
Run charmhub-lp-tool when merging pull requests.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,38 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # Only run the deploy stage when a push happens to the
+    # openstack-charmers/charmed-openstack-info repository.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'openstack-charmers/charmed-openstack-info'
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo snap install --edge charmhub-lp-tool
+        mkdir logs
+    - name: Load Launchpad Token
+      run: |
+        # Steps to generate the token:
+        # curl https://gist.githubusercontent.com/freyes/6d5304937d4fdb3431165d00b1fffe56/raw/e220b4a844d1e6be5776523f4addf8dde4a42996/launchpad-request-token.py
+        # python3 ./launchpad-request-token.py -o ./lp-credentials.txt
+        # base64 ./lp-credentials.txt
+        echo "${{ secrets.LP_CREDENTIALS }}" | base64 -d > lp-credentials.txt
+    - name: LP Sync --i-really-mean-it
+      run: |
+        export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt
+        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG sync --i-really-mean-it 2>./logs/sync.log
+    - name: LP Ensure Series --i-really-mean-it
+      run: |
+        export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt
+        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series --i-really-mean-it 2>./logs/ensure-series.log
+    - name: upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: charmhub-lp-tool-logs
+        path: logs/

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,7 +1,6 @@
 name: Tests
 
 on:
-  - push
   - pull_request
 
 jobs:
@@ -49,3 +48,23 @@ jobs:
           python -m pip install tox tox-gh-actions
       - name: Test with tox ${{ matrix.target }}
         run: tox -e ${{ matrix.target }}
+  dry-run:
+    needs: [build, lint]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo snap install --edge charmhub-lp-tool
+        mkdir logs
+    - name: LP Sync (dry-run)
+      run: |
+        charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG sync 2>./logs/sync.log
+    - name: LP Ensure Series (dry-run)
+      run: |
+        charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series 2>./logs/ensure-series.log
+    - name: upload logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: charmhub-lp-tool-logs
+        path: logs/


### PR DESCRIPTION
This change introduces a new job called "dry-run" which runs
charmhub-lp-tool sync and ensure-series in anonymous mode on pull
requests to capture any possible issues.

To apply the changes merged the github workflow deploy.yaml run
charmhub-lp-tool sync and ensure-series with the --i-really-mean-it
flag on the 'push' event, this workflow only runs when the github repo
is openstack-charmers/charmed-openstack-info and the branch is 'main'.

The logs are uploaded as artifact for inspection.

The token used belongs to the uosci-testing-bot user[0]

[0] https://launchpad.net/~uosci-testing-bot
