### PR TITLE
[gh action] Upload logs always

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,7 @@ jobs:
         charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series --i-really-mean-it 2>./logs/ensure-series.log
     - name: upload logs
       uses: actions/upload-artifact@v2
+      if: always()
       with:
         name: charmhub-lp-tool-logs
         path: logs/


### PR DESCRIPTION
When the steps fail is when the logs are the most needed, without always() the logs are lost.