### PR TITLE
ci: Run apt-get update before installing packages

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,6 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install libapt-pkg-dev
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
@@ -43,6 +44,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libapt-pkg-dev
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions

--- a/charmed_openstack_info/loader.py
+++ b/charmed_openstack_info/loader.py
@@ -167,7 +167,7 @@ class CharmProjectInfo:
 
 
 class CharmsGroupConfig:
-    """Collect together all the config files and build CharmProjectInfo objects.
+    """Group all the config files and build CharmProjectInfo objects.
 
     This collects together the files passed (which define a charm projects
     config and creates CharmProject objects to ensure git repositories and


### PR DESCRIPTION
Fixes CI errors like this:

    Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libapt-pkg-dev amd64 2.4.8
      404  Not Found [IP: 52.154.174.208 80]
    E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/a/apt/libapt-pkg-dev_2.4.8_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
    E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?