### PR TITLE
Add infinidat charms

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
@@ -1,0 +1,79 @@
+# Infinidat Charms
+defaults:
+  team: openstack-charmers
+  branches:
+    master:
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - latest/edge
+      bases:
+        - "22.04"
+        - "23.04"
+    stable/2021.1:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - 2023.1/stable
+      bases:
+        - "22.04"
+        - "23.04"
+    stable/zed:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - zed/stable
+      bases:
+        - "22.04"
+        - "22.10"
+    stable/yoga:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - zed/stable
+      bases:
+        - "20.04"
+        - "22.04"
+    stable/wallaby:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - wallaby/stable
+      bases:
+        - "20.04"
+    stable/victoria:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - victoria/stable
+      bases:
+        - "20.04"
+    stable/ussuri:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - ussuri/stable
+      bases:
+        - "20.04"
+
+projects:
+  - name: Manila subordinate Infinidat storage backend charm
+    charmhub: manila-infinidat
+    launchpad: charm-manila-infinidat
+    repository: https://opendev.org/openstack/charm-manila-infinidat.git
+
+  - name: Cinder subordinate Infinidat charm
+    charmhub: cinder-infinidat
+    launchpad: charm-cinder-infinidat
+    repository: https://opendev.org/openstack/charm-cinder-infinidat.git
+
+  - name: Infinidat tools subordinate charm for nova and cinder
+    charmhub: infinidat-tools
+    launchpad: charm-infinidat-tools
+    repository: https://opendev.org/openstack/charm-infinidat-tools.git

--- a/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
@@ -42,7 +42,7 @@ defaults:
       build-channels:
         charmcraft: "2.1/stable"
       channels:
-        - yoga/stable
+        - xena/stable
       bases:
         - "20.04"
     stable/wallaby:

--- a/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
@@ -10,7 +10,7 @@ defaults:
       bases:
         - "22.04"
         - "23.04"
-    stable/2021.1:
+    stable/2023.1:
       enabled: False
       build-channels:
         charmcraft: "2.1/stable"
@@ -33,10 +33,18 @@ defaults:
       build-channels:
         charmcraft: "2.1/stable"
       channels:
-        - zed/stable
+        - yoga/stable
       bases:
         - "20.04"
         - "22.04"
+    stable/xena:
+      enabled: False
+      build-channels:
+        charmcraft: "2.1/stable"
+      channels:
+        - yoga/stable
+      bases:
+        - "20.04"
     stable/wallaby:
       enabled: False
       build-channels:


### PR DESCRIPTION
This patch adds the lp-builder-config metadata for the 3 infinidat charms (cinder-infinidat, manila-infinidat and infinidat-tools) that support the Infinidat storage backend on OpenStack.  They've been put in a separate infinidat.yaml file as they only start from ussuri and thus the entire branches config would need to be replicated 3 times if it was included in the openstack.yaml.  This way, it's a bit cleaner until there is a better inheritance system in charmed-openstack-info lp-builder-config.