### PR TITLE
Correct infinidat charms main git branch

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/infinidat.yaml
@@ -2,7 +2,7 @@
 defaults:
   team: openstack-charmers
   branches:
-    master:
+    main:
       build-channels:
         charmcraft: "2.1/stable"
       channels:


### PR DESCRIPTION
The infinidat charms use a 'main' channel rather than 'master' channel
for the development branch.
