### PR TITLE
Add Watcher

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1983,3 +1983,16 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+  - name: OpenStack Watcher Charm
+    charmhub: watcher
+    launchpad: charm-watcher
+    repository: https://opendev.org/openstack/charm-watcher.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "22.04"
+          - "23.04"

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1996,3 +1996,17 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+
+  - name: OpenStack Watcher Dashboard Charm
+    charmhub: watcher-dashboard
+    launchpad: charm-watcher-dashboard
+    repository: https://opendev.org/openstack/charm-watcher-dashboard.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "22.04"
+          - "23.04"


### PR DESCRIPTION
This PR registers two new charms:
* charm-watcher, principal charm to configure OpenStack Watcher
* charm-watcher-dashboard, subordinate charm that extends openstack-charm to configure the watcher-ui plugin.