### PR TITLE
Use charmcraft 2.x/stable channel for master

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.1/stable"
+        charmcraft: "2.x/stable"
       channels:
         - latest/edge
       bases:


### PR DESCRIPTION
The master branch can get broken builds as long as it help us to identify backward incompatible changes in charmcraft earlier, pinning to 2.x instead of 2.1 (or 2.2, etc) allows us to switch automatically when
  the charmcraft team releases a version.