### PR TITLE
placement (stable/zed) bump up to charmcraft 2.1

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -763,7 +763,7 @@ projects:
       stable/zed:
         enabled: True
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "2.1/stable"
         channels:
           - zed/stable
         bases:


### PR DESCRIPTION
The patch available at [0] introduces the use of
reactive-charm-build-arguments which was only introduced in charmcraft-2.1[1]

[0] https://review.opendev.org/c/openstack/charm-placement/+/892033
[1] canonical/charmcraft@873697f7