### PR TITLE
Add charm-discoveryserver

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -3,6 +3,19 @@ defaults:
   team: openstack-charmers
 
 projects:
+  - name: Discoveryserver Charm
+    charmhub: discoveryserver
+    launchpad: charm-discoveryserver
+    repository: https://github.com/openstack-charmers/charm-discoveryserver.git
+    branches:
+      main:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "20.04"
+
   - name: HA Cluster Charm
     charmhub: hacluster
     launchpad: charm-hacluster


### PR DESCRIPTION
The discoveryserver charm deploys and configures the discoveryserver snap, this service allows the replacement of https://discovery.etcd.io/ with an on-prem equivalent.

This is useful for OpenStack Magnum running on restricted networks.

https://github.com/etcd-io/discoveryserver