### PR TITLE
ironic-conductor: set charmcraft to 2.0/stable

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1279,7 +1279,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "2.0/stable"
         channels:
           - yoga/stable
         bases:


### PR DESCRIPTION
A new commit introduced binary charms for ironic-conductor[0] and bumped up charmcraft to 2.0, this syncs up that change.

[0] https://review.opendev.org/c/openstack/charm-ironic-conductor/+/887116