### PR TITLE
Add bobcat 2023.2/candidate channels

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -94,7 +94,7 @@ defaults:
     stable/2023.2:
       enabled: True
       build-channels:
-        charmcraft: "2.2/stable"
+        charmcraft: "2.x/stable"
       channels:
         - 2023.2/candidate
       bases:
@@ -202,7 +202,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -304,7 +304,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -478,7 +478,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -629,7 +629,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -740,7 +740,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -835,7 +835,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -954,7 +954,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1049,7 +1049,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1134,7 +1134,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1224,7 +1224,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1319,7 +1319,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1414,7 +1414,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1492,7 +1492,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1540,7 +1540,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1630,7 +1630,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1715,7 +1715,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1805,7 +1805,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1905,7 +1905,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -1991,7 +1991,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -2118,7 +2118,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -2219,7 +2219,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -2243,7 +2243,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:
@@ -2267,7 +2267,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.2/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.2/candidate
         bases:

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -2013,15 +2013,15 @@ projects:
           - "22.04"
           - "23.04"
           - "23.10"
-        stable/2023.2:
-          enabled: True
-          build-channels:
-            charmcraft: "2.x/stable"
-          channels:
-            - 2023.2/stable
-          bases:
-            - "22.04"
-            - "23.10"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - 2023.2/stable
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Octavia Dashboard Charm
     charmhub: octavia-dashboard

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.x/stable"
+        charmcraft: "2.x/candidate"
       channels:
         - latest/edge
       bases:
@@ -94,7 +94,7 @@ defaults:
     stable/2023.2:
       enabled: True
       build-channels:
-        charmcraft: "2.x/stable"
+        charmcraft: "2.x/candidate"
       channels:
         - 2023.2/candidate
       bases:
@@ -114,7 +114,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -202,7 +202,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -217,7 +217,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -304,7 +304,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -388,7 +388,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -478,7 +478,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -539,7 +539,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -629,7 +629,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -653,7 +653,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -740,7 +740,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -755,7 +755,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -835,7 +835,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -884,7 +884,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -954,7 +954,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -969,7 +969,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1049,7 +1049,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1064,7 +1064,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1134,7 +1134,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1224,7 +1224,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1239,7 +1239,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1319,7 +1319,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1334,7 +1334,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1414,7 +1414,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1428,7 +1428,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1492,7 +1492,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1512,7 +1512,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1540,7 +1540,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1560,7 +1560,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1630,7 +1630,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1645,7 +1645,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1715,7 +1715,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1735,7 +1735,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1805,7 +1805,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1825,7 +1825,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1905,7 +1905,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -1920,7 +1920,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -1991,7 +1991,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -2006,7 +2006,7 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -2016,7 +2016,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/stable
         bases:
@@ -2030,7 +2030,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -2117,7 +2117,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -2131,7 +2131,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -2218,7 +2218,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -2232,7 +2232,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -2242,7 +2242,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:
@@ -2256,7 +2256,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - latest/edge
         bases:
@@ -2266,7 +2266,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - 2023.2/candidate
         bases:

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -2013,16 +2013,15 @@ projects:
           - "22.04"
           - "23.04"
           - "23.10"
-        #stable/2023.2:
-        #  enabled: True
-        #  build-channels:
-        #    charmcraft: "2.2/stable"
-        #  channels:
-        #    - 2023.2/stable
-        #  bases:
-        #    - "22.04"
-        #    - "23.04"
-        #    - "23.10"
+        stable/2023.2:
+          enabled: True
+          build-channels:
+            charmcraft: "2.x/stable"
+          channels:
+            - 2023.2/stable
+          bases:
+            - "22.04"
+            - "23.10"
 
   - name: OpenStack Octavia Dashboard Charm
     charmhub: octavia-dashboard

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -91,6 +91,15 @@ defaults:
       bases:
         - "22.04"
         - "23.04"
+    stable/2023.2:
+      enabled: True
+      build-channels:
+        charmcraft: "2.2/stable"
+      channels:
+        - 2023.2/candidate
+      bases:
+        - "22.04"
+        - "23.10"
 
 projects:
   - name: OpenStack Aodh Charm
@@ -190,6 +199,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Barbican Vault Charm
     charmhub: barbican-vault
@@ -283,6 +301,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Ceilometer Charm
     charmhub: ceilometer
@@ -448,6 +475,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Manila Generic Charm
     charmhub: manila-generic
@@ -590,6 +626,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Nova Cell Controller Charm
     charmhub: nova-cell-controller
@@ -692,6 +737,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Placement charm
     charmhub: placement
@@ -778,6 +832,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Swift Proxy Charm
     charmhub: swift-proxy
@@ -888,6 +951,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Cinder Purestorage Charm
     charmhub: cinder-purestorage
@@ -974,6 +1046,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Cinder Solidfire Charm
     charmhub: cinder-solidfire
@@ -1050,6 +1131,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Cinder NetApp Charm
     charmhub: cinder-netapp
@@ -1131,6 +1221,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Ironic API Charm
     charmhub: ironic-api
@@ -1217,6 +1316,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Ironic Conductor Charm
     charmhub: ironic-conductor
@@ -1303,6 +1411,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Ironic Dashboard Charm
     charmhub: ironic-dashboard
@@ -1372,6 +1489,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Keystone Kerberos Charm
     charmhub: keystone-kerberos
@@ -1411,6 +1537,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Keystone SAML Mellon Charm
     charmhub: keystone-saml-mellon
@@ -1492,6 +1627,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
@@ -1568,6 +1712,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard
@@ -1649,6 +1802,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Neutron API Arista Plugin charm
     charmhub: neutron-api-plugin-arista
@@ -1740,6 +1902,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Neutron API OVN Plugin Charm
     charmhub: neutron-api-plugin-ovn
@@ -1817,6 +1988,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Neutron Dynamic Routing Charm
     charmhub: neutron-dynamic-routing
@@ -1935,6 +2115,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Octavia Disk-Image Retrofit Charm
     charmhub: octavia-diskimage-retrofit
@@ -2027,6 +2216,16 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
+          - "23.10"
+
   - name: OpenStack Watcher Charm
     charmhub: watcher
     launchpad: charm-watcher
@@ -2040,6 +2239,15 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+          - "23.10"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
           - "23.10"
 
   - name: OpenStack Watcher Dashboard Charm
@@ -2055,4 +2263,13 @@ projects:
         bases:
           - "22.04"
           - "23.04"
+          - "23.10"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.2/stable"
+        channels:
+          - 2023.2/candidate
+        bases:
+          - "22.04"
           - "23.10"


### PR DESCRIPTION
Add the bobcat 2023.2 channes for the OpenStack charms. The recipe is to
push to /candidate for SQA to consume prior to releasing to stable. Bug
fixes during the testing period will therefore be pushed to /candidate
to assist with simplified testing of any fixes.

The charmcraft 2.2/stable channel has been selected for the recipes as
that is the latest stable channel availble for long term building of the
bobcat charms.

Bases 22.04 and 23.10 have been selected to support jammy and mantic.
