### PR TITLE
Fix the repo link for ceph-osd

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/ceph.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ceph.yaml
@@ -404,7 +404,7 @@ projects:
   - name: Ceph OSD Charm
     charmhub: ceph-osd
     launchpad: charm-ceph-osd
-    repository: http://opendev.org/openstack/charm-ceph-osd.git
+    repository: https://opendev.org/openstack/charm-ceph-osd.git
 
   - name: Ceph Proxy Charm
     charmhub: ceph-proxy


### PR DESCRIPTION
It should point to https and not http; otherwise it breaks
charmhub-lp-tool when doing channel copies.
