### PR TITLE
Remove unknown recipes when syncing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: LP Sync --i-really-mean-it
       run: |
         export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt
-        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG sync --i-really-mean-it 2>./logs/sync.log
+        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG sync --remove-unknown --i-really-mean-it 2>./logs/sync.log
     - name: LP Ensure Series --i-really-mean-it
       run: |
         export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt


### PR DESCRIPTION
The lp-build-config has to be the last word in recipes for the repos/LP
projects that are managed as if a channel is moved from one branch to
another the *old* recipe will still be maintained resulting in two
recipes pushing to the same branch. This could lead to really weird
conflicts.

Thus, either charmed-openstack-info *is* the only metadata and controls
the repos automatically, or we need to remove the auto-syncing.  I'm in
favour of the former, and so this change removes unknown (to
charmed-openstack-info) recipes when merging a change to the repos.
