### PR TITLE
Switch ceph and ovn charms to build with charmcraft from 2.x/candidate

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/ceph.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ceph.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.x/stable"
+        charmcraft: "2.x/candidate"
       channels:
         - reef/candidate
         - latest/edge
@@ -68,7 +68,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge
@@ -121,7 +121,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge
@@ -184,7 +184,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge
@@ -247,7 +247,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge
@@ -310,7 +310,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge
@@ -359,7 +359,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge
@@ -422,7 +422,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "2.x/candidate"
         channels:
           - reef/candidate
           - latest/edge

--- a/charmed_openstack_info/data/lp-builder-config/ovn.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ovn.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.x/stable"
+        charmcraft: "2.x/candidate"
       channels:
         - latest/edge
       bases:


### PR DESCRIPTION
The 2.x/candidate channel has charmcraft-2.5 which gained support to build charms using the ubuntu-23.10 base.