### PR TITLE
Add stable/23.09 CD metadata for ovn charms

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/ovn.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ovn.yaml
@@ -61,6 +61,15 @@ defaults:
       bases:
         - "22.04"
         - "23.04"
+    stable/23.09:
+      build-channels:
+        # Needs to be candidate at the moment to pick up 2.5.0
+        charmcraft: "2.x/candidate"
+      channels:
+        - 23.09/candidate
+      bases:
+        - "22.04"
+        - "23.10"
 
 projects:
   - name: OVN Central


### PR DESCRIPTION
This is to support the 23.09 release and enable building/pushing to
charmhub from launchpad for the ovn charms.
