### PR TITLE
2023.2 Stable release for 23.10 charmed release.

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -96,7 +96,7 @@ defaults:
       build-channels:
         charmcraft: "2.x/candidate"
       channels:
-        - 2023.2/candidate
+        - 2023.2/stable
       bases:
         - "22.04"
         - "23.10"
@@ -204,7 +204,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -306,7 +306,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -480,7 +480,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -631,7 +631,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -742,7 +742,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -837,7 +837,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -956,7 +956,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1051,7 +1051,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1136,7 +1136,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1226,7 +1226,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1321,7 +1321,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1416,7 +1416,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1494,7 +1494,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1542,7 +1542,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1632,7 +1632,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1717,7 +1717,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1807,7 +1807,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1907,7 +1907,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -1993,7 +1993,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -2119,7 +2119,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -2220,7 +2220,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -2244,7 +2244,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"
@@ -2268,7 +2268,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2023.2/candidate
+          - 2023.2/stable
         bases:
           - "22.04"
           - "23.10"

--- a/charmed_openstack_info/data/lp-builder-config/ovn.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ovn.yaml
@@ -61,6 +61,15 @@ defaults:
       bases:
         - "22.04"
         - "23.04"
+    stable/23.09:
+      build-channels:
+        # Needs to be candidate at the moment to pick up 2.5.0
+        charmcraft: "2.x/candidate"
+      channels:
+        - 23.09/stable
+      bases:
+        - "22.04"
+        - "23.10"
 
 projects:
   - name: OVN Central


### PR DESCRIPTION
This switches the publishing of openstack charms for stable/2023.2 to
the 2023.2/stable channel, and for ovn stable/23.09 to 23.09/stable
channel for the release of bobcat 2023.2.  Note that ceph is staying on
reef/candidate as the charms now follow a slightly different release
strategy.
