### PR TITLE
Add 2024.1 recipes for jammy-caracal

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -100,6 +100,14 @@ defaults:
       bases:
         - "22.04"
         - "23.10"
+    stable/2024.1:
+      enabled: True
+      build-channels:
+        charmcraft: "2.x/candidate"
+      channels:
+        - 2024.2/candidate
+      bases:
+        - "22.04"
 
 projects:
   - name: OpenStack Aodh Charm
@@ -208,6 +216,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Barbican Vault Charm
     charmhub: barbican-vault
@@ -310,6 +326,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Ceilometer Charm
     charmhub: ceilometer
@@ -484,6 +508,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Manila Generic Charm
     charmhub: manila-generic
@@ -635,6 +667,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Nova Cell Controller Charm
     charmhub: nova-cell-controller
@@ -746,6 +786,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Placement charm
     charmhub: placement
@@ -841,6 +889,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Swift Proxy Charm
     charmhub: swift-proxy
@@ -946,6 +1002,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Cinder Purestorage Charm
     charmhub: cinder-purestorage
@@ -1041,6 +1105,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Cinder Solidfire Charm
     charmhub: cinder-solidfire
@@ -1126,6 +1198,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Cinder NetApp Charm
     charmhub: cinder-netapp
@@ -1216,6 +1296,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Ironic API Charm
     charmhub: ironic-api
@@ -1311,6 +1399,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Ironic Conductor Charm
     charmhub: ironic-conductor
@@ -1406,6 +1502,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Ironic Dashboard Charm
     charmhub: ironic-dashboard
@@ -1484,6 +1588,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Keystone Kerberos Charm
     charmhub: keystone-kerberos
@@ -1532,6 +1644,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Keystone SAML Mellon Charm
     charmhub: keystone-saml-mellon
@@ -1622,6 +1742,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
@@ -1707,6 +1835,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard
@@ -1797,6 +1933,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Neutron API Arista Plugin charm
     charmhub: neutron-api-plugin-arista
@@ -1897,6 +2041,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Neutron API OVN Plugin Charm
     charmhub: neutron-api-plugin-ovn
@@ -1983,6 +2135,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Neutron Dynamic Routing Charm
     charmhub: neutron-dynamic-routing
@@ -2008,6 +2168,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Octavia Dashboard Charm
     charmhub: octavia-dashboard
@@ -2109,6 +2277,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Octavia Disk-Image Retrofit Charm
     charmhub: octavia-diskimage-retrofit
@@ -2210,6 +2386,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Watcher Charm
     charmhub: watcher
@@ -2260,6 +2444,14 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"
 
   - name: OpenStack Watcher Dashboard Charm
     charmhub: watcher-dashboard
@@ -2310,3 +2502,11 @@ projects:
         bases:
           - "22.04"
           - "23.10"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2024.2/candidate
+        bases:
+          - "22.04"


### PR DESCRIPTION
Add the stable/2024.1 metadata for build stable/2024.1 jammy-caracal
charms to be pushed to the 2024.1/candidate track.
