### PR TITLE
Customise keystone-saml-mellon for yoga

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1537,6 +1537,105 @@ projects:
     charmhub: keystone-saml-mellon
     launchpad: charm-keystone-saml-mellon
     repository: https://opendev.org/openstack/charm-keystone-saml-mellon.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - latest/edge
+        bases:
+          - "16.04"
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "23.04"
+          - "23.10"
+      stable/train:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - train/edge
+          - stein/edge
+          - rocky/edge
+          - queens/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # queens, rocky and stein recipes at all those will be served from
+          # stable/train
+          - queens
+          - rocky
+          - stein
+      stable/ussuri:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - ussuri/stable
+        bases:
+          - "18.04"
+          - "20.04"
+      stable/victoria:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - victoria/stable
+        bases:
+          - "20.04"
+      stable/wallaby:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - wallaby/stable
+        bases:
+          - "20.04"
+      stable/xena:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - xena/stable
+        bases:
+          - "20.04"
+      stable/yoga:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.1/stable"
+        channels:
+          - zed/stable
+        bases:
+          - "22.04"
+          - "22.10"
+      stable/2023.1:
+        enabled: True
+        build-channels:
+          charmcraft: "2.1/stable"
+        channels:
+          - 2023.1/stable
+        bases:
+          - "22.04"
+          - "23.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "2.x/candidate"
+        channels:
+          - 2023.2/stable
+        bases:
+          - "22.04"
+          - "23.10"
 
   - name: OpenStack Magnum Charm
     charmhub: magnum


### PR DESCRIPTION
The charm has recently become 'binary' and thus needs to build on 22.04.
This requires 2.0/stable charmcraft, so this patches specialises the
branch recipes to make that change.  Sadly, its and all-or-nothing for
customisation over the default, and a single branch can't be modified.
