### PR TITLE
Add legacy build recipe for magpie charm.

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -65,6 +65,11 @@ projects:
           charmcraft: "2.x/stable"
         channels:
           - latest/edge
+      legacy:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - legacy/stable
 
   - name: MySQL InnoDB Cluster Charm
     charmhub: mysql-innodb-cluster


### PR DESCRIPTION
The magpie charm has a git branch 'legacy'; this has no recipe so there
is no 'CD' part of the testing pipeline. This patch add the CD part.
