### PR TITLE
Amend channel that stable/2024.1 is pushed to

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -105,7 +105,7 @@ defaults:
       build-channels:
         charmcraft: "2.x/candidate"
       channels:
-        - 2024.2/candidate
+        - 2024.1/candidate
       bases:
         - "22.04"
 
@@ -221,7 +221,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -331,7 +331,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -513,7 +513,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -672,7 +672,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -791,7 +791,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -894,7 +894,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1007,7 +1007,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1110,7 +1110,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1203,7 +1203,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1301,7 +1301,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1404,7 +1404,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1507,7 +1507,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1593,7 +1593,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1649,7 +1649,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1846,7 +1846,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -1939,7 +1939,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2037,7 +2037,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2145,7 +2145,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2239,7 +2239,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2272,7 +2272,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2381,7 +2381,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2490,7 +2490,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2548,7 +2548,7 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"
 
@@ -2606,6 +2606,6 @@ projects:
         build-channels:
           charmcraft: "2.x/candidate"
         channels:
-          - 2024.2/candidate
+          - 2024.1/candidate
         bases:
           - "22.04"


### PR DESCRIPTION
This change updates the channel where charms built from stable/2024.1 are pushed to.