### PR TITLE
ceph-mon: bump charmcraft version to 2.x

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/ceph.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ceph.yaml
@@ -288,7 +288,7 @@ projects:
       stable/quincy.2:
         series-summary: "Quincy stable charm"
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "2.x/stable"
         channels:
           - quincy/stable
         bases:


### PR DESCRIPTION
This is necessary as older charmcraft doesn't support dependency resolution via the PYDEPS mechanism, which is required by the grafana agent library