### PR TITLE
Use charmcraft 3 for some charms

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -23,14 +23,11 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/beta"
         channels:
           - latest/edge
         bases:
-          - "20.04"
-          - "22.04"
-          - "23.04"
-          - "23.10"
+          - "24.04"
       stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
@@ -73,14 +70,11 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/beta"
         channels:
           - latest/edge
         bases:
-          - "22.04"
-          - "22.10"
-          - "23.04"
-          - "23.10"
+          - "24.04"
       #stable/8.0:
       stable/jammy:
         build-channels:
@@ -98,14 +92,11 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/beta"
         channels:
           - latest/edge
         bases:
-          - "22.04"
-          - "22.10"
-          - "23.04"
-          - "23.10"
+          - "24.04"
       #stable/8.0:
       stable/jammy:
         build-channels:
@@ -143,14 +134,11 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/beta"
         channels:
           - latest/edge
         bases:
-          - "20.04"
-          - "22.04"
-          - "23.04"
-          - "23.10"
+          - "24.04"
       # jammy
       #stable/3.9:
       stable/jammy:
@@ -200,13 +188,11 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/beta"
         channels:
           - latest/edge
         bases:
-          - "22.04"
-          - "23.04"
-          - "23.10"
+          - "24.04"
       stable/1.8:
         build-channels:
           charmcraft: "2.1/stable"

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -4,16 +4,11 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.x/candidate"
+        charmcraft: "3.x/beta"
       channels:
         - latest/edge
       bases:
-        - "16.04"
-        - "18.04"
-        - "20.04"
-        - "22.04"
-        - "23.04"
-        - "23.10"
+        - "24.04"
     stable/train:
       enabled: True
       build-channels:
@@ -2157,15 +2152,11 @@ projects:
       master:
         enabled: True
         build-channels:
-          charmcraft: "2.x/candidate"
+          charmcraft: "3.x/beta"
         channels:
           - latest/edge
         bases:
-          - "20.04"
-          - "22.04"
-          - "22.10"
-          - "23.04"
-          - "23.10"
+          - "24.04"
       stable/ussuri:
         enabled: True
         build-channels:

--- a/charmed_openstack_info/data/lp-builder-config/ovn.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ovn.yaml
@@ -4,13 +4,11 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.x/candidate"
+        charmcraft: "3.x/beta"
       channels:
         - latest/edge
       bases:
-        - "22.04"
-        - "23.04"
-        - "23.10"
+        - "24.04"
     stable/20.03:
       build-channels:
         charmcraft: "1.5/stable"


### PR DESCRIPTION
Some charms are being migrated to charmcraft 3 on the master branch. Update the launchpad recipe information to reflect this.