### PR TITLE
Add stable/noble -> 3.12/stable for rabbitmq-server

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -139,6 +139,15 @@ projects:
           - latest/edge
         bases:
           - "24.04"
+      # noble
+      stable/noble:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - 3.12/stable
+        bases:
+          - "24.04"
+          - "22.04"
       # jammy
       #stable/3.9:
       stable/jammy:


### PR DESCRIPTION
Add recipe for rabbitmq-server charm for a stable/noble -> 3.12/stable
on charmhub mapping. This will be 22.04 and 24.04 support to enable
upgrading (when Juju supports series upgrade for binary charms).
