### PR TITLE
Migrate mysql-innodb-cluster 8.0 to charmcraft 2.x

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -78,7 +78,7 @@ projects:
       #stable/8.0:
       stable/jammy:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 8.0/stable
         bases:


### PR DESCRIPTION
The mysql-innodb-cluster charm on its stable/jammy branch migrated from charmcraft-1.5 to charmcraft-2.x, this change reflects that.

Depdends-On: https://review.opendev.org/c/openstack/charm-mysql-innodb-cluster/+/925158