### PR TITLE
Ceph: upload to quincy/candidate

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
         export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt
         charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series --i-really-mean-it 2>./logs/ensure-series.log
     - name: upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: charmhub-lp-tool-logs

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -66,7 +66,7 @@ jobs:
       run: |
         charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series 2>./logs/ensure-series.log
     - name: upload logs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: charmhub-lp-tool-logs
         path: logs/

--- a/charmed_openstack_info/data/lp-builder-config/ceph.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/ceph.yaml
@@ -31,7 +31,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - quincy/stable
+        - quincy/candidate
       bases:
         - "20.04"
         - "22.04"
@@ -109,7 +109,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"
@@ -176,7 +176,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"
@@ -253,7 +253,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"
@@ -330,7 +330,7 @@ projects:
         build-channels:
           charmcraft: "2.x/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"
@@ -407,7 +407,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"
@@ -470,7 +470,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"
@@ -547,7 +547,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/stable
+          - quincy/candidate
         bases:
           - "20.04"
           - "22.04"


### PR DESCRIPTION
Similar to the squid and reef tracks, don't upload directly to quincy/stable; instead use quincy/candidate to allow for extra release testing

Also switch to v4 of the upload action, as v2 is no longer supported.
