### PR TITLE
Use charmcraft 3.x/stable to build rabbitmq-server stable/noble

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -147,7 +147,7 @@ projects:
       # noble
       stable/noble:
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/stable"
         channels:
           - 3.12/stable
         bases:


### PR DESCRIPTION
The stable/noble charm is charmcraft-3.x ready and it needs to build on it since it's a noble charm