### PR TITLE
migrate nova-compute to charmcraft 2.x

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -625,6 +625,15 @@ projects:
     charmhub: nova-compute
     launchpad: charm-nova-compute
     repository: https://opendev.org/openstack/charm-nova-compute.git
+    branches:
+      stable/ussuri:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - ussuri/stable
+        bases:
+          - "18.04"
+          - "20.04"
 
   - name: OpenStack Nova Compute NVIDIA vGPU plugin charm
     charmhub: nova-compute-nvidia-vgpu


### PR DESCRIPTION
Because of [1] blocking ussuri build we have to migrate charmcraft 1.5 to 2.x.

[1] https://github.com/canonical/charmcraft/issues/2231