### PR TITLE
Add keystone-openidc for stable/yoga

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1652,6 +1652,14 @@ projects:
           - latest/edge
         bases:
           - "24.04"
+      stable/yoga:
+        enabled: True
+        build-channels:
+          charmcraft: "2.1/stable"
+        channels:
+          - yoga/candidate
+        bases:
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:


### PR DESCRIPTION
The keystone-openidc charm is going to be released for Yoga, this change introduced the recipe definition to push new builds to yoga/candidate