### PR TITLE
Update keystone-openidc recipes to charmcraft 2.x

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1655,7 +1655,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "2.x/stable"
         channels:
           - yoga/candidate
         bases:
@@ -1663,7 +1663,7 @@ projects:
       stable/zed:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "2.x/stable"
         channels:
           - zed/stable
         bases:
@@ -1672,7 +1672,7 @@ projects:
       stable/2023.1:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "2.x/stable"
         channels:
           - 2023.1/stable
         bases:


### PR DESCRIPTION
Charmcraft 2.1 fails due to dependency changes.