### PR TITLE
Bump up charmcraft for neutron-api-plugin-ovn

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libapt-pkg-dev
+        sudo apt-get install libapt-pkg-dev intltool
         python -m pip install --upgrade pip
         python -m pip install tox tox-gh-actions
     - name: Test with python ${{ matrix.python-version }}
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install libapt-pkg-dev
+          sudo apt-get install libapt-pkg-dev intltool
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions
       - name: Test with tox ${{ matrix.target }}

--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -2167,7 +2167,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "2.x/stable"
         channels:
           - yoga/stable
         bases:


### PR DESCRIPTION
Switch the charmcraft channel to 2.x/stable now that the stable/yoga branch is compatible with it.

Depends-On: https://review.opendev.org/c/openstack/charm-neutron-api-plugin-ovn/+/948912