### PR TITLE
openstack-loadbalancer: Noble (24.04) support with stable/noble branch

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -250,6 +250,15 @@ projects:
         channels:
           - latest/edge
         bases:
+          - "22.04"
+          - "24.04"
+      stable/noble:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - noble/edge
+        bases:
+          - "22.04"
           - "24.04"
       stable/jammy:
         build-channels:


### PR DESCRIPTION
Adds stable/noble branch configuration publishing to noble/edge channel with support for 22.04 and 24.04 bases.