### PR TITLE
nova-compute: Add missing branches definitions

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -611,6 +611,13 @@ projects:
     launchpad: charm-nova-compute
     repository: https://opendev.org/openstack/charm-nova-compute.git
     branches:
+      master:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "24.04"
       stable/ussuri:
         build-channels:
           charmcraft: "2.x/stable"
@@ -619,6 +626,63 @@ projects:
         bases:
           - "18.04"
           - "20.04"
+      stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - victoria/stable
+        bases:
+          - "20.04"
+      stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - wallaby/stable
+        bases:
+          - "20.04"
+      stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - xena/stable
+        bases:
+          - "20.04"
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/zed:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - zed/stable
+        bases:
+          - "22.04"
+      stable/2023.1:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - 2023.1/stable
+        bases:
+          - "22.04"
+      stable/2023.2:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - 2023.2/stable
+        bases:
+          - "22.04"
+      stable/2024.1:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - 2024.1/stable
+        bases:
+          - "22.04"
 
   - name: OpenStack Nova Compute NVIDIA vGPU plugin charm
     charmhub: nova-compute-nvidia-vgpu


### PR DESCRIPTION
Commit e0a08d8 redefined the stable/ussuri definition inherited from the `defaults` section, this change defines the missing recipes.

charmcraft-1.5 is used for >=wallaby,<=zed, because that's what this charm was inheriting from, the change that migrated this charm to charmcraft-2.x[0] was only merged in stable/ussuri.

[0] https://review.opendev.org/c/openstack/charm-nova-compute/+/945391