### PR TITLE
vault: migrate stable/1.8 to charmcraft 3.x

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -216,11 +216,12 @@ projects:
           - "24.04"
       stable/1.8:
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - 1.8/stable
         bases:
           - "22.04"
+          - "24.04"
       stable/1.7:
         build-channels:
           charmcraft: "1.5/stable"


### PR DESCRIPTION
The stable release of vault 1.8 is getting noble support, to achieve this it was needed to migrate it charmcraft-3.x, this updates the Launchpad recipe.

References: https://review.opendev.org/c/openstack/charm-vault/+/990213/