### PR TITLE
Use charmcraft 3.x/stable

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -643,6 +643,106 @@ projects:
     charmhub: openstack-dashboard
     launchpad: charm-openstack-dashboard
     repository: https://opendev.org/openstack/charm-openstack-dashboard.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "24.04"
+      stable/train:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - train/edge
+          - stein/edge
+          - rocky/edge
+          - queens/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # queens, rocky and stein recipes at all those will be served from
+          # stable/train
+          - queens
+          - rocky
+          - stein
+      stable/ussuri:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - ussuri/stable
+        bases:
+          - "18.04"
+          - "20.04"
+      stable/victoria:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - victoria/stable
+        bases:
+          - "20.04"
+      stable/wallaby:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - wallaby/stable
+        bases:
+          - "20.04"
+      stable/xena:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - xena/stable
+        bases:
+          - "20.04"
+      stable/yoga:
+        enabled: True
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - zed/stable
+        bases:
+          - "22.04"
+      stable/2023.1:
+        enabled: True
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2023.1/stable
+        bases:
+          - "22.04"
+      stable/2023.2:
+        enabled: True
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2023.2/stable
+        bases:
+          - "22.04"
+      stable/2024.1:
+        enabled: True
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2024.1/candidate
+        bases:
+          - "22.04"
+          - "24.04"
 
   - name: OpenStack Designate Charm
     charmhub: designate
@@ -1349,7 +1449,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "3.x/stable"
         channels:
           - yoga/stable
         bases:
@@ -1358,7 +1458,7 @@ projects:
       stable/zed:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - zed/stable
         bases:
@@ -1366,7 +1466,7 @@ projects:
       stable/2023.1:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.1/stable
         bases:
@@ -1374,7 +1474,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/candidate"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.2/stable
         bases:
@@ -1382,7 +1482,7 @@ projects:
       stable/2024.1:
         enabled: True
         build-channels:
-          charmcraft: "2.x/candidate"
+          charmcraft: "3.x/stable"
         channels:
           - 2024.1/candidate
         bases:
@@ -1441,7 +1541,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "3.x/stable"
         channels:
           - yoga/stable
         bases:
@@ -1450,7 +1550,7 @@ projects:
       stable/zed:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - zed/stable
         bases:
@@ -1458,7 +1558,7 @@ projects:
       stable/2023.1:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.1/stable
         bases:
@@ -1466,7 +1566,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/candidate"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.2/stable
         bases:
@@ -1485,6 +1585,80 @@ projects:
     charmhub: masakari
     launchpad: charm-masakari
     repository: https://opendev.org/openstack/charm-masakari.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "24.04"
+      stable/ussuri:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - ussuri/stable
+        bases:
+          - "18.04"
+          - "20.04"
+      stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - victoria/stable
+        bases:
+          - "20.04"
+      stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - wallaby/stable
+        bases:
+          - "20.04"
+      stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - xena/stable
+        bases:
+          - "20.04"
+      stable/yoga:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/zed:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - zed/stable
+        bases:
+          - "22.04"
+      stable/2023.1:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2023.1/stable
+        bases:
+          - "22.04"
+      stable/2023.2:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2023.2/stable
+        bases:
+          - "22.04"
+      stable/2024.1:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2024.1/candidate
+        bases:
+          - "22.04"
+          - "24.04"
 
   - name: OpenStack Masakari Monitors Charm
     charmhub: masakari-monitors
@@ -1710,6 +1884,80 @@ projects:
     charmhub: nova-cloud-controller
     launchpad: charm-nova-cloud-controller
     repository: https://opendev.org/openstack/charm-nova-cloud-controller.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "24.04"
+      stable/ussuri:
+        build-channels:
+          charmcraft: "2.x/stable"
+        channels:
+          - ussuri/stable
+        bases:
+          - "18.04"
+          - "20.04"
+      stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - victoria/stable
+        bases:
+          - "20.04"
+      stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - wallaby/stable
+        bases:
+          - "20.04"
+      stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - xena/stable
+        bases:
+          - "20.04"
+      stable/yoga:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/zed:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - zed/stable
+        bases:
+          - "22.04"
+      stable/2023.1:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2023.1/stable
+        bases:
+          - "22.04"
+      stable/2023.2:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2023.2/stable
+        bases:
+          - "22.04"
+      stable/2024.1:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 2024.1/candidate
+        bases:
+          - "22.04"
+          - "24.04"
 
   - name: OpenStack Nova Compute Charm
     charmhub: nova-compute
@@ -2067,7 +2315,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "3.x/stable"
         channels:
           - yoga/stable
         bases:
@@ -2076,7 +2324,7 @@ projects:
       stable/zed:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - zed/stable
         bases:
@@ -2084,7 +2332,7 @@ projects:
       stable/2023.1:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.1/stable
         bases:
@@ -2092,7 +2340,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/candidate"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.2/stable
         bases:
@@ -3353,7 +3601,7 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "2.x/stable"
+          charmcraft: "3.x/stable"
         channels:
           - yoga/stable
         bases:
@@ -3362,7 +3610,7 @@ projects:
       stable/zed:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - zed/stable
         bases:
@@ -3370,7 +3618,7 @@ projects:
       stable/2023.1:
         enabled: True
         build-channels:
-          charmcraft: "2.1/stable"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.1/stable
         bases:
@@ -3378,7 +3626,7 @@ projects:
       stable/2023.2:
         enabled: True
         build-channels:
-          charmcraft: "2.x/candidate"
+          charmcraft: "3.x/stable"
         channels:
           - 2023.2/stable
         bases:


### PR DESCRIPTION
Updates the following charms for master -> stable/yoga:

   * placement
   * masakari
   * manila (again)
   * manila-ganesha
   * openstack-dashboard
   * nova-cloud-controller
   * neutron-api-plugin-ovn