### PR TITLE
Skip ovn charm sync

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,11 +26,11 @@ jobs:
     - name: LP Sync --i-really-mean-it
       run: |
         export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt
-        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG sync --remove-unknown --i-really-mean-it 2>./logs/sync.log
+        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config -p openstack -p infinidat -p misc -p trilio --log DEBUG sync --remove-unknown --i-really-mean-it 2>./logs/sync.log
     - name: LP Ensure Series --i-really-mean-it
       run: |
         export LP_CREDENTIALS_FILE=$(pwd)/lp-credentials.txt
-        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series --i-really-mean-it 2>./logs/ensure-series.log
+        charmhub-lp-tool --config-dir ./charmed_openstack_info/data/lp-builder-config -p openstack -p infinidat -p misc -p trilio --log DEBUG ensure-series --i-really-mean-it 2>./logs/ensure-series.log
     - name: upload logs
       uses: actions/upload-artifact@v4
       if: always()

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -59,10 +59,10 @@ jobs:
         mkdir logs
     - name: LP Sync (dry-run)
       run: |
-        charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG sync 2>./logs/sync.log
+        charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config -p openstack -p infinidat -p misc -p trilio --log DEBUG sync 2>./logs/sync.log
     - name: LP Ensure Series (dry-run)
       run: |
-        charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config --log DEBUG ensure-series 2>./logs/ensure-series.log
+        charmhub-lp-tool --anonymous --config-dir ./charmed_openstack_info/data/lp-builder-config -p openstack -p infinidat -p misc -p trilio --log DEBUG ensure-series 2>./logs/ensure-series.log
     - name: upload logs
       if: ${{ always() }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The LP user used to deploy this information does not have access to OVN Engineering charms so need to skip to allow others to sync.