### PR TITLE
openstack: switch 2024.1 to /stable

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -97,7 +97,7 @@ defaults:
       build-channels:
         charmcraft: "3.x/stable"
       channels:
-        - 2024.1/candidate
+        - 2024.1/stable
       bases:
         - "22.04"
         - "24.04"
@@ -203,7 +203,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -304,9 +304,9 @@ projects:
       stable/2024.1:
         enabled: True
         build-channels:
-          charmcraft: "3.x/candidate"
+          charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -409,7 +409,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -514,7 +514,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -593,7 +593,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -698,7 +698,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -808,7 +808,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -913,7 +913,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1018,7 +1018,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1123,7 +1123,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1228,7 +1228,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1338,7 +1338,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1443,7 +1443,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1548,7 +1548,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1658,7 +1658,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1750,7 +1750,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1829,7 +1829,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -1934,7 +1934,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2039,7 +2039,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2128,7 +2128,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2207,7 +2207,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2314,7 +2314,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2393,7 +2393,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2501,7 +2501,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2598,7 +2598,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2706,7 +2706,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2803,7 +2803,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2891,7 +2891,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2984,7 +2984,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3081,7 +3081,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3178,7 +3178,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3260,7 +3260,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3320,7 +3320,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3425,7 +3425,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3513,7 +3513,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3601,7 +3601,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3694,7 +3694,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3796,7 +3796,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3884,7 +3884,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -3915,7 +3915,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -4018,7 +4018,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -4121,7 +4121,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -4176,7 +4176,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -4231,7 +4231,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"


### PR DESCRIPTION
The 2024.1 charms available in the candidate risk have been QA'ed and they are ready to be promoted to /stable.

The promotion of existing charms was made using charmhub-lp-tool.

    charmhub-lp-tool -p openstack copy-channel \
        -s 2024.1/candidate \
        -d 2024.1/stable \
        --base 24.04 \
        --base 22.04