### PR TITLE
misc: Add mysql charms for noble

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -87,7 +87,13 @@ projects:
           - latest/edge
         bases:
           - "24.04"
-      #stable/8.0:
+      stable/noble:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - 8.0/stable
+        bases:
+          - "24.04"
       stable/jammy:
         build-channels:
           charmcraft: "3.x/stable"
@@ -109,7 +115,13 @@ projects:
           - latest/edge
         bases:
           - "24.04"
-      #stable/8.0:
+      stable/noble:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - "8.0/stable"
+        bases:
+          - "24.04"
       stable/jammy:
         build-channels:
           charmcraft: "3.x/stable"


### PR DESCRIPTION
The stable/noble git branch supports the charms for the 24.04 base, they are pushed to the same 8.0 track that stable/jammy does. They can co-exist, charmhub supports this.