### PR TITLE
Add charm-ldap-test-fixture

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/misc.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/misc.yaml
@@ -296,6 +296,17 @@ projects:
         bases:
           - "20.04"
 
+  - name: LDAP Test Fixture Charm
+    charmhub: openstack-charmers-ldap-test-fixture
+    launchpad: charm-ldap-test-fixture
+    repository: https://github.com/openstack-charmers/charm-ldap-test-fixture.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "3.x/stable"
+        channels:
+          - latest/edge
+
   - name: OpenID Connect Test Fixture Charm
     charmhub: openidc-test-fixture
     launchpad: charm-openidc-test-fixture


### PR DESCRIPTION
This charm is used to test keystone-ldap.

This configuration was used to create git mirroring and a charm recipe that builds and publishes to charmhub.

https://code.launchpad.net/charm-ldap-test-fixture
https://launchpad.net/~openstack-charmers/charm-ldap-test-fixture/+charm/charm-ldap-test-fixture.master.latest