### PR TITLE
Fix residual 2024.1/candidate in prev commit

### DIFF
--- a/charmed_openstack_info/data/lp-builder-config/openstack.yaml
+++ b/charmed_openstack_info/data/lp-builder-config/openstack.yaml
@@ -1627,7 +1627,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2192,7 +2192,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"
@@ -2271,7 +2271,7 @@ projects:
         build-channels:
           charmcraft: "3.x/stable"
         channels:
-          - 2024.1/candidate
+          - 2024.1/stable
         bases:
           - "22.04"
           - "24.04"


### PR DESCRIPTION
Commit dbd35c5 contained some charms still publishing to 2024.1/candidate but all charms have been switched to stable so this fixes those charms.